### PR TITLE
Add Show Env Navigation Item, Drop setSubmitMode

### DIFF
--- a/chromeExtension/package.json
+++ b/chromeExtension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gotdibbs-toolbox",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Admin tools for Dynamics 365/CRM",
   "main": "index.js",
   "scripts": {

--- a/chromeExtension/src/components/AppStateProvider.js
+++ b/chromeExtension/src/components/AppStateProvider.js
@@ -116,6 +116,9 @@ function getAppState() {
             version: dynamicsState && dynamicsState.fullVersion
         });
 
+        const majorVersion = dynamicsState.version ?
+            parseInt(dynamicsState.version.split('.')[0], 10) : 0;
+
         const isForm = (dynamicsState.context && dynamicsState.context.Xrm &&
             dynamicsState.context.Xrm.Page &&
             dynamicsState.context.Xrm.Page.ui && dynamicsState.context.Xrm.Page.data &&
@@ -133,7 +136,7 @@ function getAppState() {
                 recordId = xrm.Page.data.entity.getId && xrm.Page.data.entity.getId();
             }
             catch (e) {
-                if (version < 9) {
+                if (majorVersion < 9) {
                     // Swallow intermittent errors
                     return defaultState;
                 }
@@ -141,9 +144,6 @@ function getAppState() {
                 Honeybadger.notify(e, 'Failed to retrieve record ID while updating information panel');
             }
         }
-
-        const majorVersion = dynamicsState.version ?
-            parseInt(dynamicsState.version.split('.')[0], 10) : 0;
 
         return {
             isForm,

--- a/chromeExtension/src/components/OpenObjectModal.js
+++ b/chromeExtension/src/components/OpenObjectModal.js
@@ -147,7 +147,7 @@ export default function OpenObjectModal() {
                             <div className="gotdibbs-toolbox-modal-form-field">
                                 <label>Record Logical Name <span style={{ color: 'red' }}>*</span></label>
                                 <input type="text" name="logicalName" ref={register({ required: true })} autoFocus data-testid="recordlogicalname" />
-                                {errors.logicalName && (<small style={{ color: 'red' }}>Record Logical Name is required</small>)}
+                                {errors.logicalName && (<span style={{ color: 'red' }}>Record Logical Name is required</span>)}
                             </div>
                         ) : null}
 
@@ -155,7 +155,7 @@ export default function OpenObjectModal() {
                             <div className="gotdibbs-toolbox-modal-form-field">
                                 <label>Record Id</label>
                                 <input type="text" name="id" ref={register({ pattern: guidRegex })} data-testid="recordid" />
-                                {errors.id && (<small style={{ color: 'red' }}>ID must be a valid GUID</small>)}
+                                {errors.id && (<span style={{ color: 'red' }}>ID must be a valid GUID</span>)}
                             </div>
                         ) : null}
 
@@ -163,7 +163,7 @@ export default function OpenObjectModal() {
                             <div className="gotdibbs-toolbox-modal-form-field">
                                 <label>Solution Unique Name <span style={{ color: 'red' }}>*</span></label>
                                 <input type="text" name="solutionUniqueName" ref={register({ required: true })} autoFocus data-testid="solutionuniquename" />
-                                {errors.solutionUniqueName && (<small style={{ color: 'red' }}>Solution Unique Name is required</small>)}
+                                {errors.solutionUniqueName && (<span style={{ color: 'red' }}>Solution Unique Name is required</span>)}
                             </div>
                         ) : null}
 
@@ -171,7 +171,7 @@ export default function OpenObjectModal() {
                             <div className="gotdibbs-toolbox-modal-form-field">
                                 <label>Field Logical Name <span style={{ color: 'red' }}>*</span></label>
                                 <input type="text" name="fieldLogicalName" ref={register({ required: true })} autoFocus data-testid="fieldLogicalName" />
-                                {errors.fieldLogicalName && (<small style={{ color: 'red' }}>Field Logical Name is required</small>)}
+                                {errors.fieldLogicalName && (<span style={{ color: 'red' }}>Field Logical Name is required</span>)}
                             </div>
                         ) : null}
                     </div>

--- a/chromeExtension/src/components/UtilitiesTab.js
+++ b/chromeExtension/src/components/UtilitiesTab.js
@@ -13,7 +13,7 @@ export default function UtilitiesTab() {
 
     return (
         <section data-page="utilities">
-            <ul style={{ fontSize: '12px', listSTyleType: 'none' }}>
+            <ul style={{ listSTyleType: 'none' }}>
                 {
                     Utilities.filter(utility => {
                         if (utility.maxVersion && utility.maxVersion < state.majorVersion) {

--- a/chromeExtension/src/navigation/environmentVariables.js
+++ b/chromeExtension/src/navigation/environmentVariables.js
@@ -1,0 +1,21 @@
+import Honeybadger from 'honeybadger-js';
+import * as Fathom from 'fathom-client';
+
+function navigate() {
+    const xrm = window.__GOTDIBBS_TOOLBOX__.context.Xrm;
+
+    window.open([
+        xrm.Page.context.getClientUrl(),
+        '/main.aspx?pagetype=entitylist&etn=environmentvariabledefinition'
+    ].join(''), '_blank');
+
+
+    Fathom.trackGoal('A1HF26K2', 0);
+}
+
+export default {
+    navigate: Honeybadger.wrap(navigate),
+    isVisible: true,
+    key: 'show-environment-variables',
+    title: 'Show Environment Variables'
+};

--- a/chromeExtension/src/navigation/index.js
+++ b/chromeExtension/src/navigation/index.js
@@ -4,6 +4,7 @@ import { default as openList } from './openList';
 import { default as openRecord } from './openRecord';
 import { default as openSolution } from './openSolution';
 import { default as pluginTraceLog } from './pluginTraceLog';
+import { default as environmentVariables } from './environmentVariables';
 import { default as solutionHistory } from './solutionHistory';
 
 // Export such that they're ordered
@@ -14,5 +15,6 @@ export default [
     openRecord,
     openSolution,
     pluginTraceLog,
+    environmentVariables,
     solutionHistory
 ];

--- a/chromeExtension/src/styles/modal.css
+++ b/chromeExtension/src/styles/modal.css
@@ -46,6 +46,14 @@
     margin-top: 1em;
 }
 
+.gotdibbs-toolbox-modal-form-field input {
+    border: 1px solid #444;
+    border-radius: 0;
+    font-size: 1.5em;
+    margin: 0.25em 0;
+    padding: 0.25em;
+}
+
 .gotdibbs-toolbox-modal-buttons {
     display: flex;
     justify-content: flex-end;
@@ -70,6 +78,7 @@
     color: rgb(59, 121, 183);
 }
 
+.gotdibbs-toolbox-modal-button:focus,
 .gotdibbs-toolbox-modal-button:hover {
     font-weight: bold;
 }

--- a/chromeExtension/src/utilities/enable-all-fields.js
+++ b/chromeExtension/src/utilities/enable-all-fields.js
@@ -1,6 +1,6 @@
 import * as Fathom from 'fathom-client';
 
-function enableAllFields() {
+function enableAllFields({ majorVersion }) {
     const xrm = window.__GOTDIBBS_TOOLBOX__.context.Xrm;
 
     xrm.Page.ui.controls.forEach(function(c, i){
@@ -9,11 +9,14 @@ function enableAllFields() {
         }
     });
 
-    xrm.Page.data.entity.attributes.forEach(function(c, i){
-        if (c && c.setSubmitMode) {
-            c.setSubmitMode('always');
-        }
-    });
+    // Version 9+ should rely on an alreay set submit mode of dirty, and works even on disabled fields
+    if (majorVersion < 9) {
+        xrm.Page.data.entity.attributes.forEach(function(c, i){
+            if (c && c.setSubmitMode) {
+                c.setSubmitMode('always');
+            }
+        });
+    }
 
     Fathom.trackGoal('WVP4ETTK', 0);
 }

--- a/chromeExtension/tests/integration/config/wdio.conf-local.js
+++ b/chromeExtension/tests/integration/config/wdio.conf-local.js
@@ -5,8 +5,8 @@ exports.config = {
     logLevel: 'warn',
     specFileRetries: 0,
     services: [
-        //['chromedriver', {}]
-        ['browserstack', {}]
+        ['chromedriver', {}]
+        //['browserstack', {}]
     ],
     capabilities: [
         {
@@ -18,6 +18,6 @@ exports.config = {
     ],
     // Uncomment the below to specify a specific feature file to run
     specs: [
-        './features/utilities.feature'
+        './features/navigation.feature'
     ]
 };

--- a/chromeExtension/tests/integration/features/navigation.feature
+++ b/chromeExtension/tests/integration/features/navigation.feature
@@ -30,6 +30,11 @@ Feature: Navigation Pane
     When I click on the plugin-trace-logs link
     Then A new window should open with "Plug-in Trace Logs" in the title
 
+  Scenario: Plugin Trace Logs
+    Given I am on the navigation pane
+    When I click on the show-environment-variables link
+    Then A new window should open with "Environment Variable Definition" in the title
+
   Scenario: Solution History
     Given I am on the navigation pane
     When I click on the solution-history link

--- a/chromeExtension/tests/integration/features/utilities.feature
+++ b/chromeExtension/tests/integration/features/utilities.feature
@@ -1,34 +1,34 @@
 Feature: Utilities Pane
 
-#   Scenario: Copy Record Id
+  Scenario: Copy Record Id
 
-#     Given I am on the utilities pane and viewing a record
-#     When I invoke the copy-record-id action
-#     Then I should have copied the record id to my clipboard
+    Given I am on the utilities pane and viewing a record
+    When I invoke the copy-record-id action
+    Then I should have copied the record id to my clipboard
 
-#   Scenario: Copy Record Link
+  Scenario: Copy Record Link
 
-#     Given I am on the utilities pane and viewing a record
-#     When I invoke the copy-record-link action
-#     Then I should have copied the record url to my clipboard
+    Given I am on the utilities pane and viewing a record
+    When I invoke the copy-record-link action
+    Then I should have copied the record url to my clipboard
 
-#   Scenario: Unlock All Fields
+  Scenario: Unlock All Fields
 
-#     Given I am on the utilities pane and viewing a record
-#     When I disable a field, then invoke the enable-all-fields action
-#     Then The field I disabled is reenabled
+    Given I am on the utilities pane and viewing a record
+    When I disable a field, then invoke the enable-all-fields action
+    Then The field I disabled is reenabled
 
-#   Scenario: Focus Field
+  Scenario: Focus Field
 
-#     Given I am on the utilities pane and viewing a record
-#     When I invoke the focus-field action
-#     Then The field specified should have received focus
+    Given I am on the utilities pane and viewing a record
+    When I invoke the focus-field action
+    Then The field specified should have received focus
 
-#   Scenario: Enable Command Checker
+  Scenario: Enable Command Checker
 
-#     Given I am on the utilities pane and viewing a record
-#     When I invoke the open-ribbon-debugger action
-#     Then I see the command checker
+    Given I am on the utilities pane and viewing a record
+    When I invoke the open-ribbon-debugger action
+    Then I see the command checker
 
   Scenario: Populate Required Fields
 


### PR DESCRIPTION
- Add Show Environment Variables to pull up the ENV list for now
- Drop `setSubmitMode` logic for v9 which appears to not need it anymore (on the Unlock All Fields utility)
- Cleanup Open Modal Dialog styles
- Add and (oops) uncomment tests
- Fix undefined var issue